### PR TITLE
Support more lax schema constraints

### DIFF
--- a/src/local/collection.ts
+++ b/src/local/collection.ts
@@ -29,7 +29,7 @@ export interface CollectionConfig {
   /**
    * The JSON Schema definition for instance validation
    */
-  schema?: JSONSchema;
+  schema?: JSONSchema | any;
   /**
    * A set of fields to use for indexing
    */

--- a/src/middleware/schemas/index.ts
+++ b/src/middleware/schemas/index.ts
@@ -18,8 +18,8 @@ export type JSONType = JSONSchema4Type; // | JSONSchema6Type | JSONSchema7Type;
 
 declare module "dexie" {
   export interface Table {
-    setSchema(schema?: JSONSchema): Promise<void>;
-    getSchema(): Promise<JSONSchema>;
+    setSchema(schema?: JSONSchema | any): Promise<void>;
+    getSchema(): Promise<JSONSchema | any>;
   }
 }
 
@@ -46,7 +46,7 @@ export function createSchemaMiddleware(core: DBCore): DBCore {
           const pair = await core
             .table(SchemasTableName)
             .get({ key: tableName, trans: req.trans });
-          const schema: JSONSchema = pair?.schema ?? defaultSchema;
+          const schema: JSONSchema | any = pair?.schema ?? defaultSchema;
           const validator = new Ajv({ useDefaults: true }).compile(schema);
           // We only need to worry about validation when mutating data
           try {


### PR DESCRIPTION
Right now, our schema constraints are more strict that in js threads and js textile, this relaxes these to make it easier to support schemas across libraries.