### PR TITLE
Feature/optional id field on create

### DIFF
--- a/src/local/collection.ts
+++ b/src/local/collection.ts
@@ -130,7 +130,7 @@ export class Collection<T = unknown> {
    * This does not automatically commit the instance to the collection.
    * @param data The input data to use when initializing the document.
    */
-  create(data?: T): Document<T> & Instance {
+  create(data?: T & { _id?: string }): Document<T> & Instance {
     // TODO: Create is actually used differently in the Go clients, should we rename this?
     const cls = this.table.schema.mappedClass;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/local/collection.ts
+++ b/src/local/collection.ts
@@ -130,7 +130,7 @@ export class Collection<T = unknown> {
    * This does not automatically commit the instance to the collection.
    * @param data The input data to use when initializing the document.
    */
-  create(data?: T & { _id?: string }): Document<T> & Instance {
+  create(data?: Omit<T, "_id"> & { _id?: string }): Document<T> & Instance {
     // TODO: Create is actually used differently in the Go clients, should we rename this?
     const cls = this.table.schema.mappedClass;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/local/db.ts
+++ b/src/local/db.ts
@@ -106,7 +106,7 @@ export class Database {
    * Get an existing local collection.
    * @param name The name of the collection.
    */
-  collection<T = unknown>(name: string): Collection<T> | undefined {
+  collection<T = any>(name: string): Collection<T> | undefined {
     let collection = this.collectionMap.get(name);
     if (collection !== undefined) {
       return collection as Collection<T>;


### PR DESCRIPTION
## Description

When working with the collection.create<T> function, I am using a type that looks like:

```typescript
export interface EntityHeader {
  _id: string
  namespaceId: string
  name: string
  classId: string
  isDeprecated: boolean
  replacedBy: string
}
```

When I create a typed collection and try to use the collection.create function like this:

```typescript
const entity = repo.entHeaders.create({
  namespaceId: '1',
  name: 'name',
  classId: 'classId',
  isDeprecated: false,
  replacedBy: '',
})
```

I get a type error because in my `EntityHeader` type, _id is required.  However, when I call the create function, I want threaddb to create an _id for me and not throw a type error when I don't want to include it.

I also would prefer to leave _id typed as 'string' rather than 'string | unknown', because everywhere other than the create function will have a string value for this field.

EDIT: I had to alter the signature of create() to `create(data?: Omit<T, "_id"> & { _id?: string })`.  I forgot to add Omit<T, "_id"> which is necessary to remove any existing `_id` property (potentially non-nullable) before re-adding `_id?: string` as a nullable field.
